### PR TITLE
Fix video thumbnail broken since Chrome 76

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,6 +67,7 @@ Thumbnail.prototype.createThumbnailFromVideoFile = function() {
 Thumbnail.prototype.createVideoThumbnailFromUrl = function(videoUrl) {
   var canPlay, videoElem;
   videoElem = document.createElement('video');
+  videoElem.setAttribute('preload', 'auto')
   videoElem.style = 'display: none';
   document.body.appendChild(videoElem);
   canPlay = videoElem.canPlayType(this.options.file.type);


### PR DESCRIPTION
Chrome since version 76 stops preloading the videos on `video` elements if not necessary (like hidden videos). This caused screenshots to be blank (black canvas). Adding the `preload` attribute to the `video` element with the `auto` value makes it preload and we get the first frame available for the screenshot.